### PR TITLE
Port unit-tests from cdap/common to tigon-common.

### DIFF
--- a/tigon-common/pom.xml
+++ b/tigon-common/pom.xml
@@ -26,6 +26,12 @@ the License.
 
   <artifactId>tigon-common</artifactId>
 
+  <properties>
+    <!-- Workaround for bug http://jira.codehaus.org/browse/MRESOURCES-99 -->
+    <project.info.buildtime>${maven.build.timestamp}</project.info.buildtime>
+    <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss.SSSZ</maven.build.timestamp.format>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>co.cask.tigon</groupId>
@@ -62,4 +68,24 @@ the License.
     </dependency>
   </dependencies>
 
+  <build>
+    <!-- Resource filtering for non xml files only -->
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <excludes>
+          <exclude>**/*.xml</exclude>
+        </excludes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+        <includes>
+          <include>**/*.xml</include>
+        </includes>
+      </resource>
+    </resources>
+  </build>
 </project>
+

--- a/tigon-common/src/main/java/co/cask/tigon/internal/io/ReflectionDatumWriter.java
+++ b/tigon-common/src/main/java/co/cask/tigon/internal/io/ReflectionDatumWriter.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.internal.io;
+
+import co.cask.tigon.io.Encoder;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.primitives.Longs;
+import com.google.common.reflect.TypeToken;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * A {@link DatumWriter} that uses java reflection to encode data. The encoding schema it uses is
+ * the same as the binary encoding as specified in Avro, with the enhancement of support non-string
+ * map key.
+ *
+ * @param <T> Type T to be written.
+ */
+public final class ReflectionDatumWriter<T> implements DatumWriter<T> {
+
+  private final Schema schema;
+
+  public ReflectionDatumWriter(Schema schema) {
+    this.schema = schema;
+  }
+
+  public Schema getSchema() {
+    return schema;
+  }
+
+  @Override
+  public void encode(T data, Encoder encoder) throws IOException {
+    Set<Object> seenRefs = Sets.newIdentityHashSet();
+    write(data, encoder, schema, seenRefs);
+  }
+
+  private void write(Object object, Encoder encoder, Schema objSchema, Set<Object> seenRefs) throws IOException {
+    if (object != null) {
+      if (seenRefs.contains(object)) {
+        throw new IOException("Circular reference not supported.");
+      }
+      if (objSchema.getType() == Schema.Type.RECORD) {
+        seenRefs.add(object);
+      }
+    }
+
+    switch(objSchema.getType()) {
+      case NULL:
+        encoder.writeNull();
+        break;
+      case BOOLEAN:
+        encoder.writeBool((Boolean) object);
+        break;
+      case INT:
+        encoder.writeInt(((Number) object).intValue());
+        break;
+      case LONG:
+        encoder.writeLong(((Number) object).longValue());
+        break;
+      case FLOAT:
+        encoder.writeFloat((Float) object);
+        break;
+      case DOUBLE:
+        encoder.writeDouble((Double) object);
+        break;
+      case STRING:
+        encoder.writeString(object.toString());
+        break;
+      case BYTES:
+        writeBytes(object, encoder);
+        break;
+      case ENUM:
+        writeEnum(object.toString(), encoder, objSchema);
+        break;
+      case ARRAY:
+        writeArray(object, encoder, objSchema.getComponentSchema(), seenRefs);
+        break;
+      case MAP:
+        writeMap(object, encoder, objSchema.getMapSchema(), seenRefs);
+        break;
+      case RECORD:
+        writeRecord(object, encoder, objSchema, seenRefs);
+        break;
+      case UNION:
+        // Assumption in schema generation that index 0 is the object type, index 1 is null.
+        if (object == null) {
+          encoder.writeInt(1);
+        } else {
+          seenRefs.remove(object);
+          encoder.writeInt(0);
+          write(object, encoder, objSchema.getUnionSchema(0), seenRefs);
+        }
+        break;
+    }
+  }
+
+  private void writeBytes(Object object, Encoder encoder) throws IOException {
+    if (object instanceof ByteBuffer) {
+      encoder.writeBytes((ByteBuffer) object);
+    } else if (object instanceof UUID) {
+      UUID uuid = (UUID)  object;
+      ByteBuffer buf = ByteBuffer.allocate(Longs.BYTES * 2);
+      buf.putLong(uuid.getMostSignificantBits()).putLong(uuid.getLeastSignificantBits());
+      encoder.writeBytes((ByteBuffer) buf.flip());
+    } else {
+      encoder.writeBytes((byte[]) object);
+    }
+  }
+
+  private void writeEnum(String value, Encoder encoder, Schema schema) throws IOException {
+    int idx = schema.getEnumIndex(value);
+    if (idx < 0) {
+      throw new IOException("Invalid enum value " + value);
+    }
+    encoder.writeInt(idx);
+  }
+
+  private void writeArray(Object array, Encoder encoder,
+                          Schema componentSchema, Set<Object> seenRefs) throws IOException {
+    int size = 0;
+    if (array instanceof Collection) {
+      Collection col = (Collection) array;
+      encoder.writeInt(col.size());
+      for (Object obj : col) {
+        write(obj, encoder, componentSchema, seenRefs);
+      }
+      size = col.size();
+    } else {
+      size = Array.getLength(array);
+      encoder.writeInt(size);
+      for (int i = 0; i < size; i++) {
+        write(Array.get(array, i), encoder, componentSchema, seenRefs);
+      }
+    }
+    if (size > 0) {
+      encoder.writeInt(0);
+    }
+  }
+
+  private void writeMap(Object map, Encoder encoder, Map.Entry<Schema,
+                                                                Schema> mapSchema,
+                        Set<Object> seenRefs) throws IOException {
+    Map<?, ?> objMap = (Map<?, ?>) map;
+    int size = objMap.size();
+    encoder.writeInt(size);
+    for (Map.Entry<?, ?> entry : objMap.entrySet()) {
+      write(entry.getKey(), encoder, mapSchema.getKey(), seenRefs);
+      write(entry.getValue(), encoder, mapSchema.getValue(), seenRefs);
+    }
+    if (size > 0) {
+      encoder.writeInt(0);
+    }
+  }
+
+  private void writeRecord(Object record, Encoder encoder,
+                           Schema recordSchema, Set<Object> seenRefs) throws IOException {
+    try {
+      TypeToken<?> type = TypeToken.of(record.getClass());
+
+      Map<String, Method> methods = collectByMethod(type, Maps.<String, Method>newHashMap());
+      Map<String, Field> fields = collectByFields(type, Maps.<String, Field>newHashMap());
+
+      for (Schema.Field field : recordSchema.getFields()) {
+        String fieldName = field.getName();
+        Object value;
+        Field recordField = fields.get(fieldName);
+        if (recordField != null) {
+          recordField.setAccessible(true);
+          value = recordField.get(record);
+        } else {
+          Method method = methods.get(fieldName);
+          if (method == null) {
+            throw new IOException("Unable to read field value through getter. Class=" + type + ", field=" + fieldName);
+          }
+          value = method.invoke(record);
+        }
+
+        Schema fieldSchema = field.getSchema();
+        write(value, encoder, fieldSchema, seenRefs);
+      }
+    } catch (Exception e) {
+      if (e instanceof IOException) {
+        throw (IOException) e;
+      }
+      throw new IOException(e);
+    }
+  }
+
+  private Map<String, Field> collectByFields(TypeToken<?> typeToken, Map<String, Field> fields) {
+    // Collect the field types
+    for (TypeToken<?> classType : typeToken.getTypes().classes()) {
+      Class<?> rawType = classType.getRawType();
+      if (rawType.equals(Object.class)) {
+        // Ignore all object fields
+        continue;
+      }
+
+      for (Field field : rawType.getDeclaredFields()) {
+        if (Modifier.isTransient(field.getModifiers()) || field.isSynthetic()) {
+          continue;
+        }
+        fields.put(field.getName(), field);
+      }
+    }
+    return fields;
+  }
+
+  private Map<String, Method> collectByMethod(TypeToken<?> typeToken, Map<String, Method> methods) {
+    for (Method method : typeToken.getRawType().getMethods()) {
+      if (method.getDeclaringClass().equals(Object.class)) {
+        // Ignore all object methods
+        continue;
+      }
+      String methodName = method.getName();
+      if (!(methodName.startsWith("get") || methodName.startsWith("is"))
+           || method.isSynthetic() || method.getParameterTypes().length != 0) {
+        // Ignore not getter methods
+        continue;
+      }
+      String fieldName = methodName.startsWith("get") ?
+                           methodName.substring("get".length()) : methodName.substring("is".length());
+      if (fieldName.isEmpty()) {
+        continue;
+      }
+      fieldName = String.format("%c%s", Character.toLowerCase(fieldName.charAt(0)), fieldName.substring(1));
+      if (methods.containsKey(fieldName)) {
+        continue;
+      }
+      methods.put(fieldName, method);
+    }
+    return methods;
+  }
+}

--- a/tigon-common/src/main/resources/build.properties
+++ b/tigon-common/src/main/resources/build.properties
@@ -1,0 +1,18 @@
+#
+# Copyright © 2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+project.info.version=${project.version}
+project.info.build.time=${project.info.buildtime}

--- a/tigon-common/src/test/java/co/cask/tigon/conf/CConfigurationTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/conf/CConfigurationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.conf;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Testing CConfiguration.
+ */
+public class CConfigurationTest {
+
+  @Test
+  public void testConfiguration() throws Exception {
+    // first test empty config object
+    CConfiguration conf = CConfiguration.create();
+    String a = conf.get("conf.test.A");
+    String b = conf.get("conf.test.B");
+    Assert.assertNull(a);
+    Assert.assertNull(b);
+    // load some defaults and make sure they work
+    conf.addResource("test-default.xml");
+    a = conf.get("conf.test.A");
+    b = conf.get("conf.test.B");
+    Assert.assertNotNull(a);
+    Assert.assertNotNull(b);
+    assertEquals("A", a);
+    assertEquals("B", b);
+    // override one of the defaults and verify
+    conf.addResource("test-override.xml");
+    a = conf.get("conf.test.A");
+    b = conf.get("conf.test.B");
+    Assert.assertNotNull(a);
+    Assert.assertNotNull(b);
+    assertEquals("A", a);
+    assertEquals("B+", b);
+  }
+
+  @Test
+  public void testAddedConfiguration() throws Exception {
+    CConfiguration conf = CConfiguration.create();
+    conf.addResource("test-default.xml");
+    conf.set("conf.test.addedA", "AddedA");
+    conf.set("conf.test.addedB", "AddedB");
+    conf.set("conf.test.A", "A+");
+    Assert.assertNotNull(conf.get("conf.test.A"));
+    Assert.assertNotNull(conf.get("conf.test.B"));
+    Assert.assertNotNull(conf.get("conf.test.addedA"));
+    Assert.assertNotNull(conf.get("conf.test.addedB"));
+    assertEquals("A+", conf.get("conf.test.A"));
+    assertEquals("AddedA", conf.get("conf.test.addedA"));
+    assertEquals("AddedB", conf.get("conf.test.addedB"));
+  }
+
+  @Test
+  public void testMissingConfigProperties() throws Exception {
+    CConfiguration conf = CConfiguration.create();
+    conf.setInt("test.property.int", 1);
+    conf.setLong("test.property.long", 1L);
+    conf.set("test.property.longbytes", "1k");
+    conf.setFloat("test.property.float", 1.1f);
+    conf.set("test.property.boolean", "true");
+    conf.set("test.property.enum", TestEnum.FIRST.name());
+    String testRegex = ".*";
+    conf.set("test.property.pattern", testRegex);
+
+
+    try {
+      conf.getInt("missing.property");
+      fail("Expected getInt() to throw NullPointerException");
+    } catch (NullPointerException e) {
+      // expected
+    }
+    assertEquals(1, conf.getInt("test.property.int"));
+
+    try {
+      conf.getLong("missing.property");
+      fail("Expected getLong() to throw NullPointerException");
+    } catch (NullPointerException e) {
+      // expected
+    }
+    assertEquals(1L, conf.getLong("test.property.long"));
+
+    try {
+      conf.getLongBytes("missing.property");
+      fail("Expected getLongBytes() to throw NullPointerException");
+    } catch (NullPointerException e) {
+      // expected
+    }
+    assertEquals(1024L, conf.getLongBytes("test.property.longbytes"));
+
+    try {
+      conf.getFloat("missing.property");
+      fail("Expected getFloat() to throw NullPointerException");
+    } catch (NullPointerException e) {
+      // expected
+    }
+    assertEquals(1.1f, conf.getFloat("test.property.float"), 0.01f);
+
+    try {
+      conf.getBoolean("missing.property");
+      fail("Expected getBoolean() to throw NullPointerException");
+    } catch (NullPointerException e) {
+      // expected
+    }
+    assertEquals(true, conf.getBoolean("test.property.boolean"));
+
+    try {
+      conf.getEnum("missing.property", TestEnum.class);
+      fail("Expected getEnum() to throw NullPointerException");
+    } catch (NullPointerException e) {
+      // expected
+    }
+    assertEquals(TestEnum.FIRST, conf.getEnum("test.property.enum", TestEnum.class));
+
+    try {
+      conf.getPattern("missing.property");
+      fail("Expected getPattern() to throw NullPointerException");
+    } catch (NullPointerException e) {
+      // expected
+    }
+    assertEquals(testRegex, conf.getPattern("test.property.pattern").pattern());
+
+    try {
+      conf.getRange("missing.property");
+      fail("Expected getRange() to throw NullPointerException");
+    } catch (NullPointerException e) {
+      // expected
+    }
+  }
+
+  private enum TestEnum { FIRST };
+}

--- a/tigon-common/src/test/java/co/cask/tigon/election/InMemoryElectionRegistryTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/election/InMemoryElectionRegistryTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.election;
+
+import org.apache.twill.api.ElectionHandler;
+import org.apache.twill.common.Cancellable;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test for the {@link InMemoryElectionRegistry}.
+ */
+public class InMemoryElectionRegistryTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InMemoryElectionRegistryTest.class);
+
+  @Test(timeout = 5000)
+  public void testElection() throws ExecutionException, InterruptedException, BrokenBarrierException {
+    final InMemoryElectionRegistry electionRegistry = new InMemoryElectionRegistry();
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+
+    // Create 5 participants to join leader election process simultaneously
+    int participantCount = 5;
+    final CyclicBarrier barrier = new CyclicBarrier(participantCount + 1);
+    final Semaphore leaderSem = new Semaphore(0);
+    final Semaphore followerSem = new Semaphore(0);
+    final CountDownLatch[] stopLatch = new CountDownLatch[participantCount];
+
+    try {
+      final AtomicInteger currentLeader = new AtomicInteger(-1);
+      for (int i = 0; i < participantCount; i++) {
+        stopLatch[i] = new CountDownLatch(1);
+
+        final int idx = i;
+        executor.submit(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              barrier.await();
+
+              Cancellable cancel = electionRegistry.join("test", new ElectionHandler() {
+                @Override
+                public void leader() {
+                  currentLeader.set(idx);
+                  leaderSem.release();
+                }
+
+                @Override
+                public void follower() {
+                  followerSem.release();
+                }
+              });
+
+              stopLatch[idx].await(10, TimeUnit.SECONDS);
+              cancel.cancel();
+
+            } catch (Exception e) {
+              LOG.error(e.getMessage(), e);
+            }
+          }
+        });
+      }
+
+      // Sync the joining
+      barrier.await();
+
+      // There should be 1 leader and 4 followers
+      leaderSem.tryAcquire(10, TimeUnit.SECONDS);
+      followerSem.tryAcquire(participantCount - 1, 10, TimeUnit.SECONDS);
+
+      // Continuously stopping leader until there is one left.
+      for (int i = 0; i < participantCount - 1; i++) {
+        stopLatch[currentLeader.get()].countDown();
+        // Each time when the leader is unregistered from the leader election, a new leader would rise and
+        // the old leader would become a follower.
+        leaderSem.tryAcquire(10, TimeUnit.SECONDS);
+        followerSem.tryAcquire(10, TimeUnit.SECONDS);
+      }
+
+      // Withdraw the last leader, it'd become follower as well.
+      stopLatch[currentLeader.get()].countDown();
+      followerSem.tryAcquire(10, TimeUnit.SECONDS);
+
+    } finally {
+      executor.shutdown();
+      executor.awaitTermination(5L, TimeUnit.SECONDS);
+    }
+  }
+}

--- a/tigon-common/src/test/java/co/cask/tigon/io/ASMDatumCodecTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/io/ASMDatumCodecTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.io;
+
+import co.cask.tigon.internal.io.ASMDatumWriterFactory;
+import co.cask.tigon.internal.io.ASMFieldAccessorFactory;
+import co.cask.tigon.internal.io.DatumWriter;
+import co.cask.tigon.internal.io.ReflectionDatumReader;
+import co.cask.tigon.internal.io.ReflectionSchemaGenerator;
+import co.cask.tigon.internal.io.Schema;
+import co.cask.tigon.internal.io.UnsupportedTypeException;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ *
+ */
+public class ASMDatumCodecTest {
+
+  private static final ASMDatumWriterFactory DATUM_WRITER_FACTORY
+    = new ASMDatumWriterFactory(new ASMFieldAccessorFactory());
+
+  /**
+   *
+   */
+  public static enum TestEnum {
+    VALUE1, VALUE2, VALUE3, VALUE4
+  }
+
+  private <T> Schema getSchema(TypeToken<T> type) throws UnsupportedTypeException {
+    return new ReflectionSchemaGenerator().generate(type.getType());
+  }
+
+  private <T> DatumWriter<T> getWriter(TypeToken<T> type) throws UnsupportedTypeException {
+    Schema schema =  getSchema(type);
+    return DATUM_WRITER_FACTORY.create(type, schema);
+  }
+
+  @Test
+  public void testShort() throws UnsupportedTypeException, IOException {
+    TypeToken<Short> type = new TypeToken<Short>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+    DatumWriter<Short> writer = getWriter(type);
+    writer.encode((short) 3000, new BinaryEncoder(os));
+
+    ReflectionDatumReader<Short> reader = new ReflectionDatumReader<Short>(getSchema(type), type);
+    short value = reader.read(new BinaryDecoder(is), getSchema(type));
+
+    Assert.assertEquals((short) 3000, value);
+  }
+
+  @Test
+  public void testInt() throws UnsupportedTypeException, IOException {
+    TypeToken<Integer> type = new TypeToken<Integer>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+    DatumWriter<Integer> writer = getWriter(type);
+    writer.encode(12234234, new BinaryEncoder(os));
+
+    ReflectionDatumReader<Integer> reader = new ReflectionDatumReader<Integer>(getSchema(type), type);
+    int value = reader.read(new BinaryDecoder(is), getSchema(type));
+
+    Assert.assertEquals(12234234, value);
+  }
+
+  @Test
+  public void testDouble() throws UnsupportedTypeException, IOException {
+    TypeToken<Double> type = new TypeToken<Double>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+    DatumWriter<Double> writer = getWriter(type);
+    writer.encode(3.14d, new BinaryEncoder(os));
+
+    ReflectionDatumReader<Double> reader = new ReflectionDatumReader<Double>(getSchema(type), type);
+    double value = reader.read(new BinaryDecoder(is), getSchema(type));
+
+    Assert.assertEquals(3.14d, value, 0.000001d);
+  }
+
+  @Test
+  public void testString() throws UnsupportedTypeException, IOException {
+    TypeToken<String> type = new TypeToken<String>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+    DatumWriter<String> writer = getWriter(type);
+    writer.encode("Testing message", new BinaryEncoder(os));
+
+    ReflectionDatumReader<String> reader = new ReflectionDatumReader<String>(getSchema(type), type);
+    String value = reader.read(new BinaryDecoder(is), getSchema(type));
+
+    Assert.assertEquals("Testing message", value);
+  }
+
+  @Test
+  public void testUUID() throws UnsupportedTypeException, IOException {
+    TypeToken<UUID> type = new TypeToken<UUID>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+    DatumWriter<UUID> writer = getWriter(type);
+
+    UUID uuid = UUID.randomUUID();
+    writer.encode(uuid, new BinaryEncoder(os));
+
+    ReflectionDatumReader<UUID> reader = new ReflectionDatumReader<UUID>(getSchema(type), type);
+    UUID value = reader.read(new BinaryDecoder(is), getSchema(type));
+
+    Assert.assertEquals(uuid, value);
+  }
+
+  @Test
+  public void testEnum() throws UnsupportedTypeException, IOException {
+    TypeToken<TestEnum> type = new TypeToken<TestEnum>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+    DatumWriter<TestEnum> writer = getWriter(type);
+    BinaryEncoder encoder = new BinaryEncoder(os);
+    writer.encode(TestEnum.VALUE1, encoder);
+    writer.encode(TestEnum.VALUE4, encoder);
+    writer.encode(TestEnum.VALUE3, encoder);
+
+    ReflectionDatumReader<TestEnum> reader = new ReflectionDatumReader<TestEnum>(getSchema(type), type);
+
+    TestEnum value = reader.read(new BinaryDecoder(is), getSchema(type));
+    Assert.assertEquals(TestEnum.VALUE1, value);
+
+    value = reader.read(new BinaryDecoder(is), getSchema(type));
+    Assert.assertEquals(TestEnum.VALUE4, value);
+
+    value = reader.read(new BinaryDecoder(is), getSchema(type));
+    Assert.assertEquals(TestEnum.VALUE3, value);
+  }
+
+  @Test
+  public void testPrimitiveArray() throws IOException, UnsupportedTypeException {
+    TypeToken<int[]> type = new TypeToken<int[]>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+
+    int[] writeValue = {1, 2, 3, 4, -5, -6, -7, -8};
+    DatumWriter<int[]> writer = getWriter(type);
+    writer.encode(writeValue, new BinaryEncoder(os));
+
+    ReflectionDatumReader<int[]> reader = new ReflectionDatumReader<int[]>(getSchema(type), type);
+
+    int[] value = reader.read(new BinaryDecoder(is), getSchema(type));
+    Assert.assertArrayEquals(writeValue, value);
+  }
+
+  @Test
+  public void testReferenceArray() throws IOException, UnsupportedTypeException {
+    TypeToken<String[]> type = new TypeToken<String[]>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+
+    String[] writeValue = new String[] {"1", "2", null, "3"};
+    DatumWriter<String[]> writer = getWriter(type);
+    writer.encode(writeValue, new BinaryEncoder(os));
+
+    ReflectionDatumReader<String[]> reader = new ReflectionDatumReader<String[]>(getSchema(type), type);
+
+    String[] value = reader.read(new BinaryDecoder(is), getSchema(type));
+    Assert.assertArrayEquals(writeValue, value);
+  }
+
+  @Test
+  public void testList() throws IOException, UnsupportedTypeException {
+    TypeToken<List<Long>> type = new TypeToken<List<Long>>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+
+    List<Long> writeValue = ImmutableList.of(1L, 10L, 100L, 1000L);
+    DatumWriter<List<Long>> writer = getWriter(type);
+    writer.encode(writeValue, new BinaryEncoder(os));
+
+    ReflectionDatumReader<List<Long>> reader = new ReflectionDatumReader<List<Long>>(getSchema(type), type);
+
+    List<Long> value = reader.read(new BinaryDecoder(is), getSchema(type));
+    Assert.assertEquals(writeValue, value);
+  }
+
+  @Test
+  public void testMap() throws IOException, UnsupportedTypeException {
+    TypeToken<Map<String, List<String>>> type = new TypeToken<Map<String, List<String>>>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+
+    DatumWriter<Map<String, List<String>>> writer = getWriter(type);
+    ImmutableMap<String, List<String>> map = ImmutableMap.<String, List<String>>of("k1", Lists.newArrayList("v1"),
+                                                                "k2", Lists.newArrayList("v2", null));
+    writer.encode(map, new BinaryEncoder(os));
+
+    ReflectionDatumReader<Map<String, List<String>>> reader =
+      new ReflectionDatumReader<Map<String, List<String>>>(getSchema(type), type);
+
+    Assert.assertEquals(map, reader.read(new BinaryDecoder(is), getSchema(type)));
+  }
+
+  @Test
+  public void testURI() throws IOException, UnsupportedTypeException {
+    TypeToken<List<URI>> type = new TypeToken<List<URI>>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+
+    DatumWriter<List<URI>> writer = getWriter(type);
+    List<URI> writeValue = ImmutableList.of(URI.create("http://www.continuuity.com"));
+    writer.encode(writeValue, new BinaryEncoder(os));
+
+    ReflectionDatumReader<List<URI>> reader = new ReflectionDatumReader<List<URI>>(getSchema(type), type);
+    Assert.assertEquals(writeValue, reader.read(new BinaryDecoder(is), getSchema(type)));
+  }
+
+  private static class Record {
+    private int i;
+    private String s;
+    private List<String> list;
+    private TestEnum e;
+
+    public Record(int i, String s, List<String> list, TestEnum e) {
+      this.i = i;
+      this.s = s;
+      this.list = list;
+      this.e = e;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Record record = (Record) o;
+
+      return i == record.i && e == record.e && list.equals(record.list) && s.equals(record.s);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(i, s, list, e);
+    }
+  }
+
+  @Test
+  public void testRecord() throws IOException, UnsupportedTypeException {
+    TypeToken<Record> type = new TypeToken<Record>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+
+    DatumWriter<Record> writer = getWriter(type);
+    Record writeValue = new Record(10, "testing", ImmutableList.of("a", "b", "c"), TestEnum.VALUE2);
+    writer.encode(writeValue, new BinaryEncoder(os));
+
+    ReflectionDatumReader<Record> reader = new ReflectionDatumReader<Record>(getSchema(type), type);
+    Record value = reader.read(new BinaryDecoder(is), getSchema(type));
+
+    Assert.assertEquals(writeValue, value);
+  }
+
+  @Test
+  public void testRecordContainer() throws IOException, UnsupportedTypeException {
+    TypeToken<List<Record>> type = new TypeToken<List<Record>>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+
+    DatumWriter<List<Record>> writer = getWriter(type);
+    List<Record> writeValue = ImmutableList.of(
+                                  new Record(10, "testing", ImmutableList.of("a", "b", "c"), TestEnum.VALUE2));
+    writer.encode(writeValue, new BinaryEncoder(os));
+
+    ReflectionDatumReader<List<Record>> reader = new ReflectionDatumReader<List<Record>>(getSchema(type), type);
+    List<Record> value = reader.read(new BinaryDecoder(is), getSchema(type));
+
+    Assert.assertEquals(writeValue, value);
+  }
+
+  @Test
+  public void testRecordArray() throws IOException, UnsupportedTypeException {
+    TypeToken<Record[][]> type = new TypeToken<Record[][]>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+
+    DatumWriter<Record[][]> writer = getWriter(type);
+    Record[][] writeValue = new Record[][] {{ new Record(10, "testing",
+                                                         ImmutableList.of("a", "b", "c"), TestEnum.VALUE2)}};
+    writer.encode(writeValue, new BinaryEncoder(os));
+
+    ReflectionDatumReader<Record[][]> reader = new ReflectionDatumReader<Record[][]>(getSchema(type), type);
+    Record[][] value = reader.read(new BinaryDecoder(is), getSchema(type));
+
+    Assert.assertArrayEquals(writeValue, value);
+  }
+
+  /**
+   *
+   */
+  public static final class Node {
+    public int data;
+    public Node left;
+    public Node right;
+
+    public Node(int data, Node left, Node right) {
+      this.data = data;
+      this.left = left;
+      this.right = right;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Node node = (Node) o;
+
+      return data == node.data
+               && (left  != null ? left.equals(node.left) : node.left == null)
+               && (right != null ? right.equals(node.right) : node.right == null);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(data, left, right);
+    }
+  }
+
+  @Test
+  public void testTree() throws IOException, UnsupportedTypeException {
+    TypeToken<Node> type = new TypeToken<Node>() { };
+    PipedOutputStream os = new PipedOutputStream();
+    PipedInputStream is = new PipedInputStream(os);
+
+    DatumWriter<Node> writer = getWriter(type);
+    Node root = new Node(1, new Node(2, null, new Node(3, null, null)), new Node(4, new Node(5, null, null), null));
+    writer.encode(root, new BinaryEncoder(os));
+
+    ReflectionDatumReader<Node> reader = new ReflectionDatumReader<Node>(getSchema(type), type);
+    Node value = reader.read(new BinaryDecoder(is), getSchema(type));
+
+    Assert.assertEquals(root, value);
+  }
+}

--- a/tigon-common/src/test/java/co/cask/tigon/io/CodecTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/io/CodecTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.io;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+
+/**
+ *
+ */
+public class CodecTest {
+
+  @Test
+  public void testCodec() throws IOException {
+    PipedOutputStream output = new PipedOutputStream();
+    PipedInputStream input = new PipedInputStream(output);
+
+    Encoder encoder = new BinaryEncoder(output);
+    Decoder decoder = new BinaryDecoder(input);
+
+    encoder.writeNull();
+    Assert.assertNull(decoder.readNull());
+
+    encoder.writeBool(true);
+    Assert.assertTrue(decoder.readBool());
+    encoder.writeBool(false);
+    Assert.assertFalse(decoder.readBool());
+
+    encoder.writeInt(0);
+    Assert.assertEquals(0, decoder.readInt());
+    encoder.writeInt(-1);
+    Assert.assertEquals(-1, decoder.readInt());
+    encoder.writeInt(1234);
+    Assert.assertEquals(1234, decoder.readInt());
+    encoder.writeInt(-1234);
+    Assert.assertEquals(-1234, decoder.readInt());
+    encoder.writeInt(Short.MAX_VALUE);
+    Assert.assertEquals(Short.MAX_VALUE, decoder.readInt());
+    encoder.writeInt(Short.MIN_VALUE);
+    Assert.assertEquals(Short.MIN_VALUE, decoder.readInt());
+    encoder.writeInt(Integer.MAX_VALUE);
+    Assert.assertEquals(Integer.MAX_VALUE, decoder.readInt());
+    encoder.writeInt(Integer.MIN_VALUE);
+    Assert.assertEquals(Integer.MIN_VALUE, decoder.readInt());
+
+    encoder.writeLong(0);
+    Assert.assertEquals(0, decoder.readLong());
+    encoder.writeLong(-20);
+    Assert.assertEquals(-20, decoder.readLong());
+    encoder.writeLong(30000);
+    Assert.assertEquals(30000, decoder.readLong());
+    encoder.writeLong(-600000);
+    Assert.assertEquals(-600000, decoder.readLong());
+    encoder.writeLong(Integer.MAX_VALUE);
+    Assert.assertEquals(Integer.MAX_VALUE, decoder.readLong());
+    encoder.writeLong(Integer.MIN_VALUE);
+    Assert.assertEquals(Integer.MIN_VALUE, decoder.readLong());
+    encoder.writeLong(Long.MAX_VALUE);
+    Assert.assertEquals(Long.MAX_VALUE, decoder.readLong());
+    encoder.writeLong(Long.MIN_VALUE);
+    Assert.assertEquals(Long.MIN_VALUE, decoder.readLong());
+
+    encoder.writeFloat(3.14f);
+    Assert.assertEquals(3.14f, decoder.readFloat(), 0.0000001f);
+    encoder.writeFloat(Short.MAX_VALUE);
+    Assert.assertEquals(Short.MAX_VALUE, decoder.readFloat(), 0.0000001f);
+    encoder.writeFloat(Integer.MIN_VALUE);
+    Assert.assertEquals(Integer.MIN_VALUE, decoder.readFloat(), 0.0000001f);
+    encoder.writeFloat((long) Integer.MAX_VALUE * Short.MAX_VALUE);
+    Assert.assertEquals((long) Integer.MAX_VALUE * Short.MAX_VALUE, decoder.readFloat(), 0.0000001f);
+    encoder.writeFloat(Float.MAX_VALUE);
+    Assert.assertEquals(Float.MAX_VALUE, decoder.readFloat(), 0.0000001f);
+    encoder.writeFloat(Float.MIN_VALUE);
+    Assert.assertEquals(Float.MIN_VALUE, decoder.readFloat(), 0.0000001f);
+
+    encoder.writeDouble(Math.E);
+    Assert.assertEquals(Math.E, decoder.readDouble(), 0.0000001f);
+    encoder.writeDouble(Integer.MAX_VALUE);
+    Assert.assertEquals(Integer.MAX_VALUE, decoder.readDouble(), 0.0000001f);
+    encoder.writeDouble(Long.MIN_VALUE);
+    Assert.assertEquals(Long.MIN_VALUE, decoder.readDouble(), 0.0000001f);
+    encoder.writeDouble((long) Integer.MAX_VALUE * Short.MAX_VALUE);
+    Assert.assertEquals((long) Integer.MAX_VALUE * Short.MAX_VALUE, decoder.readDouble(), 0.0000001f);
+    encoder.writeDouble(Double.MAX_VALUE);
+    Assert.assertEquals(Double.MAX_VALUE, decoder.readDouble(), 0.0000001f);
+    encoder.writeDouble(Double.MIN_VALUE);
+    Assert.assertEquals(Double.MIN_VALUE, decoder.readDouble(), 0.0000001f);
+
+    encoder.writeString("This is a testing message");
+    Assert.assertEquals("This is a testing message", decoder.readString());
+    String str = Character.toString((char) 200) + Character.toString((char) 20000) + Character.toString((char) 40000);
+    encoder.writeString(str);
+    Assert.assertEquals(str, decoder.readString());
+
+    ByteBuffer buf = ByteBuffer.allocate(12);
+    buf.asIntBuffer().put(10).put(1024).put(9999999);
+    encoder.writeBytes(buf);
+    IntBuffer inBuf = decoder.readBytes().asIntBuffer();
+    Assert.assertEquals(10, inBuf.get());
+    Assert.assertEquals(1024, inBuf.get());
+    Assert.assertEquals(9999999, inBuf.get());
+  }
+}

--- a/tigon-common/src/test/java/co/cask/tigon/io/DatumCodecTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/io/DatumCodecTest.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.io;
+
+import co.cask.tigon.internal.io.DatumWriter;
+import co.cask.tigon.internal.io.ReflectionDatumReader;
+import co.cask.tigon.internal.io.ReflectionDatumWriter;
+import co.cask.tigon.internal.io.ReflectionSchemaGenerator;
+import co.cask.tigon.internal.io.Schema;
+import co.cask.tigon.internal.io.TypeRepresentation;
+import co.cask.tigon.internal.io.UnsupportedTypeException;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ *
+ */
+public class DatumCodecTest {
+
+  /**
+   *
+   */
+  public static class Value {
+    private final int id;
+    private final String name;
+
+    public Value(int id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Value value = (Value) o;
+      return id == value.id && name.equals(value.name);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = id;
+      result = 31 * result + name.hashCode();
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return "Value{" +
+        "id=" + id +
+        ", name='" + name + '\'' +
+        '}';
+    }
+  }
+
+  /**
+   *
+   */
+  public static class Record1 {
+    private final int i;
+    private final Map<Integer, Value> properties;
+    private final int[] numbers;
+    private final URL url;
+    private final UUID uuid;
+    private final String nullStr;
+
+    public Record1(int i, Map<Integer, Value> properties, URL url) {
+      this.i = i;
+      this.properties = properties;
+      this.numbers = new int[] {1, 2};
+      this.url = url;
+      this.uuid = UUID.randomUUID();
+      this.nullStr = null;
+    }
+  }
+
+  /**
+   *
+   */
+  public static class Record2 {
+    private final Long i;
+    private final Map<String, Value> properties;
+    private final String name;
+    private final long[] numbers;
+    private final URI url;
+    private final UUID uuid;
+    private final String nullStr;
+
+    public Record2(long i, Map<String, Value> properties, String name) {
+      this.i = i;
+      this.properties = properties;
+      this.name = name;
+      this.numbers = new long[0];
+      this.url = null;
+      this.uuid = null;
+      this.nullStr = null;
+    }
+  }
+
+  @Test
+  public void testTypeProject() throws IOException, UnsupportedTypeException {
+    final Record1 r1 = new Record1(10, Maps.<Integer, Value>newHashMap(), new URL("http://www.yahoo.com"));
+    r1.properties.put(1, new Value(1, "Name1"));
+    r1.properties.put(2, new Value(2, "Name2"));
+    r1.properties.put(3, null);
+
+    PipedOutputStream output = new PipedOutputStream();
+    PipedInputStream input = new PipedInputStream(output);
+
+    Schema sourceSchema = new ReflectionSchemaGenerator().generate(Record1.class);
+    Schema targetSchema = new ReflectionSchemaGenerator().generate(Record2.class);
+
+    new ReflectionDatumWriter<Record1>(sourceSchema).encode(r1, new BinaryEncoder(output));
+    Record2 r2 = new ReflectionDatumReader<Record2>(targetSchema, TypeToken.of(Record2.class))
+                            .read(new BinaryDecoder(input), sourceSchema);
+
+    Assert.assertEquals(10L, r2.i.longValue());
+
+    Assert.assertTrue(Iterables.all(r2.properties.entrySet(), new Predicate<Map.Entry<String, Value>>() {
+      @Override
+      public boolean apply(Map.Entry<String, Value> input) {
+        Value value = r1.properties.get(Integer.valueOf(input.getKey()));
+        return (value == null && input.getValue() == null) || (value.equals(input.getValue()));
+      }
+    }));
+
+    Assert.assertNull(r2.name);
+
+    Assert.assertArrayEquals(new long[] {1L, 2L}, r2.numbers);
+    Assert.assertEquals(URI.create("http://www.yahoo.com"), r2.url);
+
+    Assert.assertEquals(r1.uuid, r2.uuid);
+  }
+
+  @Test
+  public void testCollection() throws UnsupportedTypeException, IOException {
+    List<String> list = Lists.newArrayList("1", "2", "3");
+    Schema sourceSchema = new ReflectionSchemaGenerator().generate(new TypeToken<List<String>>() { }.getType());
+    Schema targetSchema = new ReflectionSchemaGenerator().generate(new TypeToken<Set<String>>() { }.getType());
+
+    PipedOutputStream output = new PipedOutputStream();
+    PipedInputStream input = new PipedInputStream(output);
+
+    new ReflectionDatumWriter<List<String>>(sourceSchema).encode(list, new BinaryEncoder(output));
+    Set<String> set = new ReflectionDatumReader<Set<String>>(targetSchema, new TypeToken<Set<String>>() { })
+                        .read(new BinaryDecoder(input), sourceSchema);
+
+    Assert.assertEquals(Sets.newHashSet("1", "2", "3"), set);
+
+
+    targetSchema = new ReflectionSchemaGenerator().generate(String[].class);
+    new ReflectionDatumWriter<List<String>>(sourceSchema).encode(list, new BinaryEncoder(output));
+    String[] array = new ReflectionDatumReader<String[]>(targetSchema, new TypeToken<String[]>() { })
+                        .read(new BinaryDecoder(input), sourceSchema);
+
+    Assert.assertArrayEquals(new String[]{"1", "2", "3"}, array);
+  }
+
+  /**
+   *
+   */
+  public static final class Node {
+    int d;
+    Node next;
+  }
+
+  @Test(expected = IOException.class)
+  public void testCircularRef() throws UnsupportedTypeException, IOException {
+    Schema schema = new ReflectionSchemaGenerator().generate(Node.class);
+
+    Node head = new Node();
+    head.next = new Node();
+    head.next.next = head;
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    new ReflectionDatumWriter<Node>(schema).encode(head, new BinaryEncoder(output));
+  }
+
+
+  /**
+   *
+   */
+  public static final class MoreFields {
+
+    static final class Inner {
+      final Map<String, String> map;
+      final String b;
+
+      Inner(String b) {
+        this.b = b;
+        map = ImmutableMap.of("b", b);
+      }
+    }
+
+    final int i;
+    final double d;
+    final String k;
+    final List<String> list;
+    final Inner inner;
+
+    public MoreFields(int i, double d, String k, List<String> list) {
+      this.i = i;
+      this.d = d;
+      this.k = k;
+      this.list = list;
+      inner = new Inner("inner");
+    }
+  }
+
+  /**
+   *
+   */
+  public static final class LessFields {
+    static final class Inner {
+      String b;
+    }
+
+    String k;
+    Inner inner;
+  }
+
+  @Test
+  public void testReduceProjection() throws IOException, UnsupportedTypeException {
+    PipedOutputStream output = new PipedOutputStream();
+    PipedInputStream input = new PipedInputStream(output);
+
+    Schema sourceSchema = new ReflectionSchemaGenerator().generate(MoreFields.class);
+    Schema targetSchema = new ReflectionSchemaGenerator().generate(LessFields.class);
+
+    MoreFields moreFields = new MoreFields(10, 20.2, "30", ImmutableList.of("1", "2"));
+    new ReflectionDatumWriter<MoreFields>(sourceSchema).encode(moreFields, new BinaryEncoder(output));
+    LessFields lessFields = new ReflectionDatumReader<LessFields>(targetSchema, TypeToken.of(LessFields.class))
+                                            .read(new BinaryDecoder(input), sourceSchema);
+
+    Assert.assertEquals("30", lessFields.k);
+    Assert.assertEquals(moreFields.inner.b, lessFields.inner.b);
+  }
+
+  /**
+   *
+   */
+  public static enum TestEnum {
+    VALUE1, VALUE2, VALUE3
+  }
+
+  @Test
+  public void testEnum() throws IOException, UnsupportedTypeException {
+    PipedOutputStream output = new PipedOutputStream();
+    PipedInputStream input = new PipedInputStream(output);
+
+    Schema schema = new ReflectionSchemaGenerator().generate(TestEnum.class);
+    ReflectionDatumWriter<TestEnum> writer = new ReflectionDatumWriter<TestEnum>(schema);
+    BinaryEncoder encoder = new BinaryEncoder(output);
+    writer.encode(TestEnum.VALUE1, encoder);
+    writer.encode(TestEnum.VALUE3, encoder);
+    writer.encode(TestEnum.VALUE2, encoder);
+
+    BinaryDecoder decoder = new BinaryDecoder(input);
+    ReflectionDatumReader<TestEnum> reader = new ReflectionDatumReader<TestEnum>(schema, TypeToken.of(TestEnum.class));
+
+    Assert.assertEquals(TestEnum.VALUE1, reader.read(decoder, schema));
+    Assert.assertEquals(TestEnum.VALUE3, reader.read(decoder, schema));
+    Assert.assertEquals(TestEnum.VALUE2, reader.read(decoder, schema));
+  }
+
+  // this tests that the datum reader treats empty fields correctly.
+  @Test
+  public void testEmptyValue() throws UnsupportedTypeException, IOException {
+    Schema schema = new ReflectionSchemaGenerator().generate(RecordWithString.class);
+    TypeRepresentation typeRep = new TypeRepresentation(RecordWithString.class);
+    DatumWriter<RecordWithString> datumWriter = new ReflectionDatumWriter<RecordWithString>(schema);
+    @SuppressWarnings("unchecked")
+    ReflectionDatumReader<RecordWithString> datumReader = new ReflectionDatumReader<RecordWithString>(
+      schema, (TypeToken<RecordWithString>) TypeToken.of(typeRep.toType()));
+
+    RecordWithString record = new RecordWithString();
+    record.setA(42);
+    record.setTheString("");
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    BinaryEncoder encoder = new BinaryEncoder(bos);
+    datumWriter.encode(record, encoder);
+    byte[] bytes = bos.toByteArray();
+
+    ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+    BinaryDecoder decoder = new BinaryDecoder(bis);
+    RecordWithString rec = datumReader.read(decoder, schema);
+
+    Assert.assertEquals(record.getA(), rec.getA());
+    Assert.assertEquals(record.getTheString(), rec.getTheString());
+  }
+}
+
+// dummy class for testEmptyValue()
+class RecordWithString {
+  int a;
+
+  int getA() {
+    return a;
+  }
+
+  void setA(int a) {
+    this.a = a;
+  }
+
+  private String theString;
+
+  String getTheString() {
+    return theString;
+  }
+
+  void setTheString(String theString) {
+    this.theString = theString;
+  }
+}
+

--- a/tigon-common/src/test/java/co/cask/tigon/io/FieldAccessorTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/io/FieldAccessorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.io;
+
+import co.cask.tigon.internal.io.ASMFieldAccessorFactory;
+import co.cask.tigon.internal.io.FieldAccessor;
+import co.cask.tigon.internal.io.FieldAccessorFactory;
+import com.google.common.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class FieldAccessorTest {
+
+  /**
+   * Test parent.
+   * @param <T>
+   */
+  public static class Parent<T> {
+    private T value;
+    private boolean b;
+  }
+
+  /**
+   * Test child.
+   */
+  public static class Child extends Parent<String> {
+    protected String str;
+    int integer;
+  }
+
+  @Test
+  public void testGetter() {
+    TypeToken<Child> type = TypeToken.of(Child.class);
+
+    FieldAccessorFactory factory = new ASMFieldAccessorFactory();
+    FieldAccessor accessor = factory.getFieldAccessor(type, "integer");
+
+    Assert.assertSame(accessor, factory.getFieldAccessor(type, "integer"));
+
+    Child c = new Child();
+    c.integer = 10;
+    c.str = "child value";
+    ((Parent<String>) c).value = "string value";
+    ((Parent<String>) c).b = true;
+
+    Assert.assertEquals(c.integer, accessor.getInt(c));
+    Assert.assertSame(c.str, factory.getFieldAccessor(type, "str").get(c));
+    Assert.assertSame(((Parent) c).value, factory.getFieldAccessor(type, "value").get(c));
+    Assert.assertEquals(((Parent) c).b, factory.getFieldAccessor(type, "b").get(c));
+  }
+
+  @Test
+  public void testSetter() {
+    TypeToken<Child> type = TypeToken.of(Child.class);
+
+    FieldAccessorFactory factory = new ASMFieldAccessorFactory();
+
+    Child c = new Child();
+    c.integer = 10;
+    c.str = "child value";
+    ((Parent<String>) c).value = "string value";
+    ((Parent<String>) c).b = true;
+
+    Child c2 = new Child();
+
+    factory.getFieldAccessor(type, "integer").setInt(c2, c.integer);
+    factory.getFieldAccessor(type, "str").set(c2, c.str);
+    factory.getFieldAccessor(type, "value").set(c2, ((Parent) c).value);
+    factory.getFieldAccessor(type, "b").setBoolean(c2, ((Parent) c).b);
+
+    Assert.assertEquals(c.integer, c2.integer);
+    Assert.assertSame(c.str, c2.str);
+    Assert.assertSame(((Parent) c).value, ((Parent) c2).value);
+    Assert.assertEquals(((Parent) c).b, ((Parent) c2).b);
+  }
+}

--- a/tigon-common/src/test/java/co/cask/tigon/io/SchemaTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/io/SchemaTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.io;
+
+import co.cask.tigon.internal.io.ReflectionSchemaGenerator;
+import co.cask.tigon.internal.io.Schema;
+import co.cask.tigon.internal.io.SchemaTypeAdapter;
+import co.cask.tigon.internal.io.UnsupportedTypeException;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test for schema generation.
+ */
+public class SchemaTest {
+
+  /**
+   * Test node.
+   */
+  public final class Node {
+    private int data;
+    private List<Node> children;
+  }
+
+  /**
+   * Test parent.
+   * @param <T> Parameter
+   */
+  public class Parent<T> {
+    private T data;
+    private ByteBuffer buffer;
+  }
+
+  /**
+   * Test child.
+   * @param <T> Paramter.
+   */
+  public class Child<T> extends Parent<Map<String, T>> {
+    private int height;
+    private Node rootNode;
+    private State state;
+  }
+
+  /**
+   * Test enum.
+   */
+  public enum State {
+    OK, ERROR
+  }
+
+
+  @Test
+  public void testGenerateSchema() throws UnsupportedTypeException {
+    Schema schema = (new ReflectionSchemaGenerator()).generate((new TypeToken<Child<Node>>() { }).getType());
+
+    Gson gson = new GsonBuilder()
+      .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+      .create();
+
+    Assert.assertEquals(schema, gson.fromJson(gson.toJson(schema), Schema.class));
+  }
+
+  /**
+   * Testing more node.
+   */
+  public final class Node2 {
+    private int data;
+    private List<Node2> children;
+  }
+
+  @Test
+  public void testSchemaHash() throws UnsupportedTypeException {
+    Schema s1 = new ReflectionSchemaGenerator().generate(Node.class);
+    Schema s2 = new ReflectionSchemaGenerator().generate(Node2.class);
+
+    Assert.assertEquals(s1.getSchemaHash(), s2.getSchemaHash());
+    Assert.assertEquals(s1, s2);
+
+    Schema schema = (new ReflectionSchemaGenerator()).generate((new TypeToken<Child<Node>>() { }).getType());
+    Assert.assertNotEquals(s1.getSchemaHash(), schema.getSchemaHash());
+  }
+
+  /**
+   * Yet more node.
+   */
+  public final class Node3 {
+    private long data;
+    private String tag;
+    private List<Node3> children;
+  }
+
+  /**
+   * More and more node.
+   */
+  public final class Node4 {
+    private String data;
+  }
+
+  @Test
+  public void testCompatible() throws UnsupportedTypeException {
+    Schema s1 = new ReflectionSchemaGenerator().generate(Node.class);
+    Schema s2 = new ReflectionSchemaGenerator().generate(Node3.class);
+    Schema s3 = new ReflectionSchemaGenerator().generate(Node4.class);
+
+    Assert.assertNotEquals(s1, s2);
+    Assert.assertTrue(s1.isCompatible(s2));
+    Assert.assertFalse(s2.isCompatible(s1));
+
+    Assert.assertTrue(s2.isCompatible(s3));
+  }
+
+  @Test
+  public void testPrimitiveArray() throws UnsupportedTypeException {
+    Schema schema = new ReflectionSchemaGenerator().generate(int[].class);
+    Assert.assertEquals(Schema.arrayOf(Schema.of(Schema.Type.INT)), schema);
+  }
+}

--- a/tigon-common/src/test/java/co/cask/tigon/lang/InstantiatorTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/lang/InstantiatorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.lang;
+
+import co.cask.tigon.internal.lang.FieldVisitor;
+import co.cask.tigon.internal.lang.Reflections;
+import com.google.common.base.Defaults;
+import com.google.common.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+/**
+ *
+ */
+public class InstantiatorTest {
+
+  @Test
+  public void testUnsafe() {
+    Record record = new InstantiatorFactory(false).get(TypeToken.of(Record.class)).create();
+
+    Reflections.visit(record, TypeToken.of(Record.class), new FieldVisitor() {
+      @Override
+      public void visit(Object instance, TypeToken<?> inspectType,
+                        TypeToken<?> declareType, Field field) throws Exception {
+        if (!Modifier.isStatic(field.getModifiers())) {
+          Assert.assertEquals(Defaults.defaultValue(field.getType()), field.get(instance));
+        }
+      }
+    });
+  }
+
+  public static final class Record {
+    private static final Logger LOG = LoggerFactory.getLogger(Record.class);
+
+    private boolean bool;
+    private byte b;
+    private char c;
+    private short s;
+    private int i;
+    private long l;
+    private float f;
+    private double d;
+    private String str;
+
+    // Just to avoid having default constructor.
+    public Record(String s) {
+    }
+  }
+}
+

--- a/tigon-common/src/test/java/co/cask/tigon/lang/ReflectionsTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/lang/ReflectionsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.lang;
+
+import co.cask.tigon.internal.lang.Reflections;
+import com.google.common.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ *
+ */
+public class ReflectionsTest {
+
+  @Test
+  public void testResolved() throws Exception {
+    Assert.assertTrue(Reflections.isResolved(String.class));
+    Assert.assertTrue(Reflections.isResolved(new TypeToken<Map<String, Set<Integer>>>() { }.getType()));
+
+    TypeToken<Record<Set<Integer>>> typeToken = new TypeToken<Record<Set<Integer>>>() { };
+    Type arrayType = Record.class.getMethod("getArray").getGenericReturnType();
+    Assert.assertFalse(Reflections.isResolved(arrayType));
+    Assert.assertTrue(Reflections.isResolved(typeToken.resolveType(arrayType).getType()));
+  }
+
+  private interface Record<T> {
+
+    T get();
+
+    T[] getArray();
+  }
+}

--- a/tigon-common/src/test/java/co/cask/tigon/logging/LogCollectorTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/logging/LogCollectorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.logging;
+
+import co.cask.tigon.conf.CConfiguration;
+import co.cask.tigon.conf.Constants;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+public class LogCollectorTest {
+
+  String makeMessage(int i) {
+    return String.format("This is error message %5d.", i);
+  }
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private void testCollection(CConfiguration config, Configuration hConfig) throws IOException {
+
+    String logtag = "a:b:c";
+    int lengthOfOne = String.format("%s [%s] %s\n", logtag, "ERROR",
+                                    makeMessage(10000)).getBytes(LogFileWriter.CHARSET_UTF8).length;
+
+    // start a log collector with 3 instances and space for 11 messages each
+    // (file rolls after a message is logged, hence the extra 2 bytes make
+    // space for an extra message.
+    config.setInt(LogConfiguration.CFG_ROLL_INSTANCES, 3);
+    config.setInt(LogConfiguration.CFG_ROLL_THRESHOLD, 10 * lengthOfOne + 2);
+    LogCollector collector = new LogCollector(config, hConfig);
+
+    // write 5 messages, they should all be in the same file
+    for (int i = 0; i < 5; i++) {
+      collector.log(new LogEvent(logtag, "ERROR", makeMessage(i)));
+    }
+
+    // this should return only one message
+    List<String> lines = collector.tail(logtag, lengthOfOne + 10);
+    Assert.assertEquals(1, lines.size());
+
+    // this should return 3 messages
+    lines = collector.tail(logtag, 3 * lengthOfOne + 10);
+    Assert.assertEquals(3, lines.size());
+
+    // this should return only 5 messages
+    lines = collector.tail(logtag, 10 * lengthOfOne + 10);
+    Assert.assertEquals(5, lines.size());
+
+    // test that we can also read with another instance of the collector
+    LogCollector collector2 = new LogCollector(config, hConfig);
+    // this should return only one message
+    lines = collector2.tail(logtag, lengthOfOne + 10);
+    Assert.assertEquals(1, lines.size());
+
+
+    // write 6 more messages, this should roll the log after the last one
+    for (int i = 5; i < 11; i++) {
+      collector.log(new LogEvent(logtag, "ERROR", makeMessage(i)));
+    }
+
+    // this should return only one message, and that is the last one: 10
+    lines = collector.tail(logtag, lengthOfOne + 10);
+    Assert.assertEquals(1, lines.size());
+    Assert.assertTrue(lines.get(0).contains(makeMessage(10)));
+
+    // write 1 more message, this should start writing to the next file
+    collector.log(new LogEvent(logtag, "ERROR", makeMessage(11)));
+
+    // this should return two messages: 10 + 11
+    lines = collector.tail(logtag, 2 * lengthOfOne + 10);
+    Assert.assertEquals(2, lines.size());
+    Assert.assertTrue(lines.get(0).contains(makeMessage(10)));
+    Assert.assertTrue(lines.get(1).contains(makeMessage(11)));
+
+    // write 24 more messages, this should now roll and evict some
+    for (int i = 12; i < 36; i++) {
+      collector.log(new LogEvent(logtag, "ERROR", makeMessage(i)));
+    }
+
+    // read across all instances: the current file has 3, the others 11
+    // hence reading 16 should read across all 3 files
+    lines = collector.tail(logtag, 16 * lengthOfOne + 10);
+    Assert.assertEquals(16, lines.size());
+    for (int i = 0; i < 16; i++) {
+      Assert.assertTrue(lines.get(i).contains(makeMessage(i + 20)));
+    }
+
+    // read past the last instance: the current file has 3, the others 11
+    // hence reading 27 should exceed the 3 files
+    lines = collector.tail(logtag, 27 * lengthOfOne + 10);
+    Assert.assertEquals(25, lines.size());
+    for (int i = 0; i < 25; i++) {
+      Assert.assertTrue(lines.get(i).contains(makeMessage(i + 11)));
+    }
+
+    // close the log collector and reopen it
+    collector.close();
+    collector = new LogCollector(config, hConfig);
+
+    // verify that the state is the same with the new collector
+    lines = collector.tail(logtag, 27 * lengthOfOne + 10);
+    Assert.assertEquals(25, lines.size());
+    for (int i = 0; i < 25; i++) {
+      Assert.assertTrue(lines.get(i).contains(makeMessage(i + 11)));
+    }
+
+    // write 1 more message, this should append to the current file
+    collector.log(new LogEvent(logtag, "ERROR", makeMessage(36)));
+
+
+    // verify that append works and we see an additional message
+    // - if it rolls, then we lose messages
+    // - if it fails, then we don't see the new message
+    lines = collector.tail(logtag, 27 * lengthOfOne + 10);
+    Assert.assertEquals(26, lines.size());
+    for (int i = 0; i < 26; i++) {
+      Assert.assertTrue(lines.get(i).contains(makeMessage(i + 11)));
+    }
+  }
+
+  @Test
+  public void testCollectionLocalFS() throws IOException {
+
+    // create a new temp dir for the log root
+    File prefix = tempFolder.newFolder();
+
+    CConfiguration config = CConfiguration.create();
+    config.set(Constants.CFG_LOG_COLLECTION_ROOT, prefix.getAbsolutePath());
+
+    Configuration hConf = new Configuration();
+    testCollection(config, hConf);
+  }
+}

--- a/tigon-common/src/test/java/co/cask/tigon/utils/ImmutablePairTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/utils/ImmutablePairTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class ImmutablePairTest {
+
+  static final class Fixture {
+    static ImmutablePair<Integer, Integer> a = new ImmutablePair<Integer, Integer>(1, 2);
+    static ImmutablePair<Integer, String>  b = new ImmutablePair<Integer, String>(1, "woot");
+    static ImmutablePair<String, String>   c = new ImmutablePair<String, String>("me", "you");
+    static ImmutablePair<Integer, Integer> d = new ImmutablePair<Integer, Integer>(1, 2);
+    static ImmutablePair<Integer, Integer> e = new ImmutablePair<Integer, Integer>(1, 2);
+  }
+
+  @Test
+  public void testGetFirst() throws Exception {
+    Assert.assertEquals(Integer.class, Fixture.a.getFirst().getClass());
+    Assert.assertEquals(1, Fixture.a.getFirst().intValue());
+  }
+
+  @Test
+  public void testGetSecond() throws Exception {
+    Assert.assertEquals(Integer.class, Fixture.a.getSecond().getClass());
+    Assert.assertEquals(2, Fixture.a.getSecond().intValue());
+  }
+
+  @Test
+  public void testToString() throws Exception {
+    Assert.assertNotNull(Fixture.b.toString());
+    Assert.assertEquals("ImmutablePair{first=1, second=woot}", Fixture.b.toString());
+  }
+
+  @Test
+  public void testSelf() throws Exception {
+    Assert.assertTrue(Fixture.a.equals(Fixture.a));
+    Assert.assertTrue(Fixture.b.equals(Fixture.b));
+    Assert.assertTrue(Fixture.c.equals(Fixture.c));
+  }
+
+  @Test
+  public void testIncompatibleTypes()  throws Exception {
+    Assert.assertFalse(Fixture.a.equals(Fixture.c));
+    Assert.assertFalse(Fixture.a.equals(Fixture.b));
+  }
+
+  @Test
+  public void testNullReferences() throws Exception {
+    Assert.assertFalse(Fixture.a.equals(null));
+  }
+
+  @Test
+  public void testEqualsIsReflexive() {
+    Assert.assertTrue(Fixture.a.equals(Fixture.d));
+  }
+
+  @Test
+  public void testEqualsIsTransitive() {
+    Assert.assertTrue(Fixture.a.equals(Fixture.d));
+    Assert.assertTrue(Fixture.d.equals(Fixture.e));
+    Assert.assertTrue(Fixture.e.equals(Fixture.a));
+  }
+
+  @Test
+  public void testEqualsTypeSafe() {
+    ImmutablePair<Integer, Boolean> pair1 = new ImmutablePair<Integer, Boolean>(1, true);
+    ImmutablePair<String, byte[]> pair2 = new ImmutablePair<String, byte[]>("1", "true".getBytes());
+    Assert.assertFalse(pair1.equals(pair2));
+    Assert.assertFalse(pair2.equals(pair1));
+    Assert.assertFalse(pair1.equals(new Integer(10)));
+  }
+
+
+  @Test
+  public void testHashCodeConsistency() throws Exception {
+    int hashcode = Fixture.a.hashCode();
+    Assert.assertEquals(hashcode, Fixture.a.hashCode());
+    Assert.assertEquals(hashcode, Fixture.a.hashCode());
+  }
+
+  @Test
+  public void testTwoSameObjectHashCode() throws Exception {
+    Assert.assertEquals(Fixture.a.hashCode(), Fixture.d.hashCode());
+    Assert.assertEquals(Fixture.d.hashCode(), Fixture.e.hashCode());
+    Assert.assertEquals(Fixture.e.hashCode(), Fixture.a.hashCode());
+  }
+
+  @Test
+  public void testTwoDifferentObjectHashCode() throws Exception {
+    Assert.assertTrue(!(Fixture.a.hashCode() == Fixture.c.hashCode()));
+  }
+
+}

--- a/tigon-common/src/test/java/co/cask/tigon/utils/ProjectInfoTest.java
+++ b/tigon-common/src/test/java/co/cask/tigon/utils/ProjectInfoTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.tigon.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test class for testing {@link ProjectInfo}.
+ */
+public class ProjectInfoTest {
+
+  @Test
+  public void testInfo() {
+    Assert.assertTrue(ProjectInfo.getVersion().getMajor() >= 0);
+    Assert.assertTrue(ProjectInfo.getVersion().getBuildTime() > 0L);
+  }
+
+  @Test
+  public void testVersion() {
+    ProjectInfo.Version version = new ProjectInfo.Version("2.1.0-SNAPSHOT-12345");
+    Assert.assertEquals(2, version.getMajor());
+    Assert.assertEquals(1, version.getMinor());
+    Assert.assertEquals(0, version.getFix());
+    Assert.assertTrue(version.isSnapshot());
+    Assert.assertEquals(12345L, version.getBuildTime());
+
+    Assert.assertEquals("2.1.0-SNAPSHOT-12345", version.toString());
+  }
+
+  @Test
+  public void testVersionCompare() {
+    // Major version
+    ProjectInfo.Version version1 = new ProjectInfo.Version("2.1.0-SNAPSHOT-12345");
+    ProjectInfo.Version version2 = new ProjectInfo.Version("3.0.0-SNAPSHOT-12345");
+
+    Assert.assertTrue(version1.compareTo(version1) == 0);
+    Assert.assertTrue(version1.compareTo(version2) < 0);
+    Assert.assertTrue(version2.compareTo(version1) > 0);
+
+    // Minor version
+    version1 = new ProjectInfo.Version("2.0.0-SNAPSHOT-12345");
+    version2 = new ProjectInfo.Version("2.1.0-SNAPSHOT-12345");
+
+    Assert.assertTrue(version1.compareTo(version1) == 0);
+    Assert.assertTrue(version1.compareTo(version2) < 0);
+    Assert.assertTrue(version2.compareTo(version1) > 0);
+
+    // Fix version
+    version1 = new ProjectInfo.Version("2.1.0-SNAPSHOT-12345");
+    version2 = new ProjectInfo.Version("2.1.1-SNAPSHOT-12345");
+
+    Assert.assertTrue(version1.compareTo(version1) == 0);
+    Assert.assertTrue(version1.compareTo(version2) < 0);
+    Assert.assertTrue(version2.compareTo(version1) > 0);
+
+    // Snapshot, non-snapshot
+    version1 = new ProjectInfo.Version("2.1.0-SNAPSHOT-12345");
+    version2 = new ProjectInfo.Version("2.1.0-12345");
+
+    Assert.assertTrue(version1.compareTo(version1) == 0);
+    Assert.assertTrue(version1.compareTo(version2) < 0);
+    Assert.assertTrue(version2.compareTo(version1) > 0);
+
+    // Buildtime
+    version1 = new ProjectInfo.Version("2.1.0-12345");
+    version2 = new ProjectInfo.Version("2.1.0-12346");
+
+    Assert.assertTrue(version1.compareTo(version1) == 0);
+    Assert.assertTrue(version1.compareTo(version2) < 0);
+    Assert.assertTrue(version2.compareTo(version1) > 0);
+
+    // Buildtime with snapshot
+    version1 = new ProjectInfo.Version("2.1.0-SNAPSHOT-12345");
+    version2 = new ProjectInfo.Version("2.1.0-SNAPSHOT-12346");
+
+    Assert.assertTrue(version1.compareTo(version1) == 0);
+    Assert.assertTrue(version1.compareTo(version2) < 0);
+    Assert.assertTrue(version2.compareTo(version1) > 0);
+  }
+}

--- a/tigon-common/src/test/resources/test-default.xml
+++ b/tigon-common/src/test/resources/test-default.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Copyright © 2014 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+<configuration>
+
+    <property>
+        <name>conf.test.A</name>
+        <value>A</value>
+        <description>
+            A
+        </description>
+    </property>
+
+    <property>
+        <name>conf.test.B</name>
+        <value>B</value>
+        <description>
+            B
+        </description>
+    </property>
+
+</configuration>

--- a/tigon-common/src/test/resources/test-override.xml
+++ b/tigon-common/src/test/resources/test-override.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Copyright © 2014 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+<configuration>
+    <property>
+        <name>conf.test.B</name>
+        <value>B+</value>
+        <description>
+            B
+        </description>
+    </property>
+</configuration>

--- a/tigon-queue/src/test/java/co/cask/tigon/data/queue/QueueNameTest.java
+++ b/tigon-queue/src/test/java/co/cask/tigon/data/queue/QueueNameTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.tigon.data.queue;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * tests that queue name works properly.
+ */
+public class QueueNameTest {
+
+  @Test
+  public void testQueueNameForFlowlet() {
+    // create a queue name
+    QueueName queueName = QueueName.fromFlowlet("app", "flow", "flowlet", "out");
+
+    // verify all parts are correct
+    Assert.assertTrue(queueName.isQueue());
+    Assert.assertFalse(queueName.isStream());
+    Assert.assertEquals("app", queueName.getFirstComponent());
+    Assert.assertEquals("flow", queueName.getSecondComponent());
+    Assert.assertEquals("flowlet", queueName.getThirdComponent());
+    Assert.assertEquals("out", queueName.getSimpleName());
+
+    // convert to URI and back, verify again
+    queueName = QueueName.from(queueName.toURI());
+    Assert.assertTrue(queueName.isQueue());
+    Assert.assertFalse(queueName.isStream());
+    Assert.assertEquals("app", queueName.getFirstComponent());
+    Assert.assertEquals("flow", queueName.getSecondComponent());
+    Assert.assertEquals("flowlet", queueName.getThirdComponent());
+    Assert.assertEquals("out", queueName.getSimpleName());
+
+    // convert to bytes and back, verify again
+    queueName = QueueName.from(queueName.toBytes());
+    Assert.assertTrue(queueName.isQueue());
+    Assert.assertFalse(queueName.isStream());
+    Assert.assertEquals("app", queueName.getFirstComponent());
+    Assert.assertEquals("flow", queueName.getSecondComponent());
+    Assert.assertEquals("flowlet", queueName.getThirdComponent());
+    Assert.assertEquals("out", queueName.getSimpleName());
+  }
+
+  @Test
+  public void testQueueNameForStream() {
+    // create a queue name
+    QueueName queueName = QueueName.fromStream("mystream");
+    verifyStreamName(queueName, "mystream");
+
+    queueName = QueueName.fromStream("audi_test_stream");
+    verifyStreamName(queueName, "audi_test_stream");
+
+    queueName = QueueName.fromStream("audi_-test_stream");
+    verifyStreamName(queueName, "audi_-test_stream");
+  }
+
+  private void verifyStreamName(QueueName queueName, String streamName) {
+    // verify all parts are correct
+    Assert.assertFalse(queueName.isQueue());
+    Assert.assertTrue(queueName.isStream());
+    Assert.assertEquals(streamName, queueName.getFirstComponent());
+    Assert.assertNull(queueName.getSecondComponent());
+    Assert.assertNull(queueName.getThirdComponent());
+    Assert.assertEquals(streamName, queueName.getSimpleName());
+
+    // convert to URI and back, verify again
+    queueName = QueueName.from(queueName.toURI());
+    Assert.assertFalse(queueName.isQueue());
+    Assert.assertTrue(queueName.isStream());
+    Assert.assertEquals(streamName, queueName.getFirstComponent());
+    Assert.assertNull(queueName.getSecondComponent());
+    Assert.assertNull(queueName.getThirdComponent());
+    Assert.assertEquals(streamName, queueName.getSimpleName());
+
+    // convert to bytes and back, verify again
+    queueName = QueueName.from(queueName.toBytes());
+    Assert.assertFalse(queueName.isQueue());
+    Assert.assertTrue(queueName.isStream());
+    Assert.assertEquals(streamName, queueName.getFirstComponent());
+    Assert.assertNull(queueName.getSecondComponent());
+    Assert.assertNull(queueName.getThirdComponent());
+    Assert.assertEquals(streamName, queueName.getSimpleName());
+  }
+}


### PR DESCRIPTION
Copied unittests from cdap/common to tigon-common for relevant classes. 

Excluded a few unnecessary tests and fixed some, as discussed with Achal and Gokul. 

https://bamboo-prod.continuuity.com/browse/PRODRELALL-UNIT0-1/
