### PR TITLE
Manually cleaning temp directory

### DIFF
--- a/tigon-sql/src/main/java/co/cask/tigon/sql/flowlet/AbstractInputFlowlet.java
+++ b/tigon-sql/src/main/java/co/cask/tigon/sql/flowlet/AbstractInputFlowlet.java
@@ -215,7 +215,7 @@ public abstract class AbstractInputFlowlet extends AbstractFlowlet implements Pr
     try {
       FileUtils.deleteDirectory(tmpFolder);
     } catch (IOException e) {
-      LOG.info("Failed to delete {}", tmpFolder.toURI().toString());
+      LOG.warn("Failed to delete {}", tmpFolder.toURI().toString());
     }
     Services.chainStop(healthInspector, inputFlowletService);
     super.destroy();

--- a/tigon-sql/src/main/java/co/cask/tigon/sql/flowlet/AbstractInputFlowlet.java
+++ b/tigon-sql/src/main/java/co/cask/tigon/sql/flowlet/AbstractInputFlowlet.java
@@ -224,7 +224,7 @@ public abstract class AbstractInputFlowlet extends AbstractFlowlet implements Pr
 
   private void cleanTempDir(File dir) {
     Queue<File> pendingList = Queues.newArrayDeque();
-    for(File tmpFile : dir.listFiles()) {
+    for (File tmpFile : dir.listFiles()) {
       if (!tmpFile.isDirectory()) {
         if (!tmpFile.delete()) {
           LOG.info("Failed to delete {}", tmpFile.toURI().toString());


### PR DESCRIPTION
The temporary directory was not being deleted because of files in its sub-directories. 
Added explicit clean up of the temp directory tree.
