### PR TITLE
HealthInspector Fix

### DIFF
--- a/tigon-sql/src/main/java/co/cask/tigon/sql/flowlet/AbstractInputFlowlet.java
+++ b/tigon-sql/src/main/java/co/cask/tigon/sql/flowlet/AbstractInputFlowlet.java
@@ -229,7 +229,8 @@ public abstract class AbstractInputFlowlet extends AbstractFlowlet implements Pr
   public void notifyFailure(Set<String> errorProcessNames) {
     LOG.info("Missing Pings From : " + errorProcessNames.toString());
     healthInspector.stopAndWait();
-    inputFlowletService.restartService();
+    healthInspector = new HealthInspector(this);
+    inputFlowletService.restartService(healthInspector);
     healthInspector.startAndWait();
   }
 }

--- a/tigon-sql/src/main/java/co/cask/tigon/sql/internal/HealthInspector.java
+++ b/tigon-sql/src/main/java/co/cask/tigon/sql/internal/HealthInspector.java
@@ -124,6 +124,6 @@ public class HealthInspector extends AbstractIdleService {
   @Override
   protected void shutDown() throws Exception {
     monitorFuture.cancel(true);
-    heartbeatCounter.clear();
+    modelCounter.clear();
   }
 }

--- a/tigon-sql/src/main/java/co/cask/tigon/sql/internal/InputFlowletService.java
+++ b/tigon-sql/src/main/java/co/cask/tigon/sql/internal/InputFlowletService.java
@@ -86,7 +86,7 @@ public final class InputFlowletService extends AbstractIdleService {
       .setBinaryLocation(dir)
       .build();
 
-    startService();
+    startService(healthInspector);
   }
 
   @Override
@@ -95,7 +95,7 @@ public final class InputFlowletService extends AbstractIdleService {
     Services.chainStop(ioService, processInitiator, discoveryServer);
   }
 
-  public void startService() {
+  public void startService(HealthInspector healthInspector) {
     //Initializing discovery server
     discoveryServer = new DiscoveryServer(hubDataStore, healthInspector, metricsRecorder);
     discoveryServer.startAndWait();
@@ -107,8 +107,8 @@ public final class InputFlowletService extends AbstractIdleService {
     processInitiator.startAndWait();
   }
 
-  public void restartService() {
+  public void restartService(HealthInspector healthInspector) {
     Services.chainStop(processInitiator, discoveryServer);
-    startService();
+    startService(healthInspector);
   }
 }

--- a/tigon-sql/src/main/java/co/cask/tigon/sql/manager/ExternalProgramExecutor.java
+++ b/tigon-sql/src/main/java/co/cask/tigon/sql/manager/ExternalProgramExecutor.java
@@ -79,7 +79,8 @@ public final class ExternalProgramExecutor extends AbstractExecutionThreadServic
   private void killRTS() {
     try {
       Process killRTS = new ProcessBuilder("kill", "-9", "-" + pid).start();
-    } catch (IOException e) {
+      killRTS.waitFor();
+    } catch (Exception e) {
       LOG.warn("Failed to shutdown RTS process");
     }
   }
@@ -205,7 +206,7 @@ public final class ExternalProgramExecutor extends AbstractExecutionThreadServic
       @Override
       public void run() {
         try {
-          LOG.info("Shutting down {}", name);
+          LOG.info("Process {} preparing for shutdown. Waiting for EOF record.", name);
           TimeUnit.SECONDS.sleep(SHUTDOWN_TIMEOUT_SECONDS);
         } catch (InterruptedException e) {
           // If interrupted, meaning the process has been shutdown nicely.


### PR DESCRIPTION
The health inspector did not work as expected in case of multiple failures in one run. This was because the same healthInspector service could not be reset. 

I have fixed this issue for now by closing down the original healthInspector object and instantiating a new HealthInspector.

This fixes the issue and the health inspector now works as expected.
