### PR TITLE
External function support for GSQL

### DIFF
--- a/tigon-sql/src/main/java/co/cask/tigon/sql/internal/StreamBinaryGenerator.java
+++ b/tigon-sql/src/main/java/co/cask/tigon/sql/internal/StreamBinaryGenerator.java
@@ -27,6 +27,7 @@ import com.google.common.io.Files;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.io.FileUtils;
 import org.apache.twill.filesystem.Location;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,6 +102,9 @@ public class StreamBinaryGenerator {
     workDir.mkdirs();
     Location queryDir = workDir.append("query");
     queryDir.mkdirs();
+    File qDir = new File(queryDir.toURI().getPath());
+    FileUtils.copyFileToDirectory(new File(dir.append("cfg").append("external_fcns.def").toURI().getPath()), qDir);
+    FileUtils.copyFileToDirectory(new File(dir.append("cfg").append("internal_fcn.def").toURI().getPath()), qDir);
     return queryDir;
   }
 


### PR DESCRIPTION
Copying function defintion files to query directory.

Tested that we can now use FLOAT(int), which is defined in external_fcns.def
[The same buildit failed when the files were not copied to the query directory.]
