### PR TITLE
Don't generate a machine name in front of an interface set.

### DIFF
--- a/tigon-sql/src/main/c/ftacmp/parse_fta.h
+++ b/tigon-sql/src/main/c/ftacmp/parse_fta.h
@@ -662,7 +662,7 @@ public:
 	std::string to_string(){
 		std::string retval;
 
-		if(machine != "")
+		if(machine != "" && !iface_is_query)
 			retval += "'"+machine+"'.";
 		if(interface != ""){
 			if(iface_is_query){

--- a/tigon-sql/src/main/c/ftacmp/translate_fta.cc
+++ b/tigon-sql/src/main/c/ftacmp/translate_fta.cc
@@ -205,7 +205,7 @@ int main(int argc, char **argv){
 		"\t[-P] : link with PADS\n"
 		"\t[-h] : override host name.\n"
 		"\t[-c] : clean out Makefile and hfta_*.cc first.\n"
-		"\t[-R] : path to root of STREAMING\n"
+		"\t[-R] : path to root of tigon\n"
 ;
 
 //		parameters gathered from command line processing


### PR DESCRIPTION
Change the translate_config usage string to reflect the new directory structure.
