### PR TITLE
Bump to 2.15 version to avoid OoM error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -772,7 +772,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.14.1</version>
+          <version>2.15</version>
           <configuration>
             <argLine>-Xmx4096m -Djava.awt.headless=true -XX:MaxPermSize=256m</argLine>
             <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
@@ -886,7 +886,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
+        <version>2.15</version>
       </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>
@@ -1122,7 +1122,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
-              <version>2.14.1</version>
+              <version>2.15</version>
               <configuration>
                 <argLine>${argLine} -Xmx4096m -Djava.awt.headless=true -XX:MaxPermSize=256m</argLine>
               </configuration>
@@ -1224,7 +1224,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.14.1</version>
+        <version>2.15</version>
       </plugin>
       
       <plugin>

--- a/tigon-archetypes/tigon-app-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/tigon-archetypes/tigon-app-archetype/src/main/resources/archetype-resources/pom.xml
@@ -140,7 +140,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
+        <version>2.15</version>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/tigon-examples/deploy_pom.xml
+++ b/tigon-examples/deploy_pom.xml
@@ -178,7 +178,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
+        <version>2.15</version>
         <configuration>
           <argLine>-Xmx2048m</argLine>
         </configuration>

--- a/tigon-examples/pom.xml
+++ b/tigon-examples/pom.xml
@@ -192,7 +192,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.14.1</version>
+        <version>2.15</version>
         <configuration>
           <argLine>-Xmx2048m</argLine>
         </configuration>


### PR DESCRIPTION
Fixes the problem seen when running HBase94QueueTest. 

The corresponding jira for surefire plugin : https://jira.codehaus.org/browse/SUREFIRE-938
